### PR TITLE
Make Rails Dependency Less Specific

### DIFF
--- a/minions_rails.gemspec
+++ b/minions_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_development_dependency "rails", "~> 4.2.5.1"
+  s.add_development_dependency "rails", "~> 4.2.0"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "sass-rails"
 end


### PR DESCRIPTION
The current version that the rails dependency is locked to is restricting apps from updating for security patches. Locking to `~> 4.2.0` should allow for any non-breaking rails updates to be applied.
